### PR TITLE
Bugfix: rétablir la simulation de gains du wallet

### DIFF
--- a/simulateur_wallet.py
+++ b/simulateur_wallet.py
@@ -1,7 +1,82 @@
 # simulateur_wallet.py
 
+"""Outils de simulation d'investissement et gestion d'un wallet fictif."""
+
+import json
+import os
+from datetime import datetime
+
+
 SOLDE_INITIAL = 1000.0
 DUREE_SIMULATION_JOURS = 7
+FICHIER_WALLET = "wallet_simulation.json"
+FICHIER_LOGS = "logs_simulations.txt"
+
+
+def charger_solde():
+    """Charge le solde simulé depuis ``FICHIER_WALLET``."""
+    if not os.path.exists(FICHIER_WALLET):
+        return 0.0
+    try:
+        with open(FICHIER_WALLET, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return float(data.get("solde", 0.0))
+    except Exception:
+        return 0.0
+
+
+def sauvegarder_solde(solde: float) -> None:
+    """Sauvegarde le solde simulé dans ``FICHIER_WALLET``."""
+    try:
+        with open(FICHIER_WALLET, "w", encoding="utf-8") as f:
+            json.dump({"solde": float(solde)}, f, indent=2)
+    except Exception as e:
+        print(f"[ERREUR] Impossible de sauvegarder le solde : {e}")
+
+
+def mettre_a_jour_solde(gain: float) -> float:
+    """Ajoute ``gain`` au solde simulé puis le sauvegarde."""
+    solde = charger_solde()
+    solde += gain
+    sauvegarder_solde(solde)
+    return solde
+
+
+def simuler_gains(pool: dict, montant: float = 100) -> tuple[str, float]:
+    """Calcule le gain estimé sur 24h pour un montant donné."""
+    try:
+        apr = abs(float(pool.get("apr", 0)))
+        gain = montant * (apr / 100) / 365
+    except Exception:
+        gain = 0.0
+    gain_str = f"~{gain:.2f} € / 24h"
+    return gain_str, gain
+
+
+def journaliser_resultats(profil: str, solde: float, pools: list, montant: float) -> None:
+    """Ajoute un récapitulatif dans ``FICHIER_LOGS``."""
+    lignes = [
+        "\n========================================",
+        f"\U0001F4C5  {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+        f"Profil : {profil} | Solde simulé : ${solde:.2f}",
+    ]
+    for i, pool in enumerate(pools, 1):
+        gain_str, _ = simuler_gains(pool, montant)
+        nom = pool.get("nom", "?")
+        plateforme = pool.get("plateforme", "?")
+        apr = pool.get("apr", 0)
+        score = pool.get("score", 0)
+        lignes.append(f"TOP {i} - {plateforme} | {nom}")
+        lignes.append(f"  APR : {apr:.2f}% | Score : {score:.2f}")
+        lignes.append(f"  💰 Gain estimé (24h, {montant}$ simulés) : {gain_str}")
+    lignes.append("========================================\n")
+
+    try:
+        with open(FICHIER_LOGS, "a", encoding="utf-8") as f:
+            for ligne in lignes:
+                f.write(ligne + "\n")
+    except Exception as e:
+        print(f"[ERREUR] Impossible d'enregistrer les logs de simulation : {e}")
 
 def simuler_investissement(pools):
     """


### PR DESCRIPTION
## Notes
- installation de `requests` pour faire passer les tests

## Summary
- réimplémente la gestion du wallet et la journalisation des résultats
- ajoute `simuler_gains`, `charger_solde`, `mettre_a_jour_solde` et `journaliser_resultats`

## Testing
- `python test_simulation.py`
- `python test_simulateur.py`


------
https://chatgpt.com/codex/tasks/task_e_6851864ed1508322a41d9480771295d1